### PR TITLE
Fix broken package.xml files

### DIFF
--- a/smach/package.xml
+++ b/smach/package.xml
@@ -17,7 +17,8 @@
   <author>Jonathan Bohren</author>
   <author>Charles Lesire</author>
 
-  <buildtool_depend>ament_python</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/smach_ros/package.xml
+++ b/smach_ros/package.xml
@@ -20,7 +20,8 @@
   <author>Jonathan Bohren</author>
   <author>Charles Lesire</author>
 
-  <buildtool_depend>ament_python</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>


### PR DESCRIPTION
### Description

Fix broken dependency declarations in package.xml files.

Reproduce errors with:

```bash
rosdep install --from-paths src -y --ignore-src -s

ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
smach_ros: Cannot locate rosdep definition for [ament_python]
smach: Cannot locate rosdep definition for [ament_python]
```

### Motivation and Context
Avoid build errors.

### How Has This Been Tested?
Same command as above.

