### PR TITLE
fixed build warnings #85ztr57wy

### DIFF
--- a/smach/setup.cfg
+++ b/smach/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/smach
+script_dir=$base/lib/smach
 [install]
-install-scripts=$base/lib/smach
+install_scripts=$base/lib/smach

--- a/smach/setup.py
+++ b/smach/setup.py
@@ -13,12 +13,7 @@ setup(
     zip_safe=True,
     maintainer='Isaac I. Y. Saito',
     maintainer_email='gm130s@gmail.com',
-    description='''
-        SMACH is a task-level architecture for rapidly creating complex robot
-        behavior. At its core, SMACH is a ROS-independent Python library to build
-        hierarchical state machines. SMACH is a new library that takes advantage of
-        very old concepts in order to quickly create robust robot behavior with
-        maintainable and modular code.''',
+    description='SMACH is a task-level architecture for rapidly creating complex robot behavior.',
     license='BSD',
     data_files=[
         ('share/ament_index/resource_index/packages',

--- a/smach_ros/setup.cfg
+++ b/smach_ros/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/smach_ros
+script_dir=$base/lib/smach_ros
 [install]
-install-scripts=$base/lib/smach_ros
+install_scripts=$base/lib/smach_ros

--- a/smach_ros/setup.py
+++ b/smach_ros/setup.py
@@ -13,12 +13,7 @@ setup(
     zip_safe=True,
     maintainer='Isaac I. Y. Saito',
     maintainer_email='gm130s@gmail.com',
-    description='''
-        SMACH is a task-level architecture for rapidly creating complex robot
-        behavior. At its core, SMACH is a ROS-independent Python library to build
-        hierarchical state machines. SMACH is a new library that takes advantage of
-        very old concepts in order to quickly create robust robot behavior with
-        maintainable and modular code.''',
+    description='SMACH is a task-level architecture for rapidly creating complex robot behavior.',
     license='BSD',
     data_files=[
         ('share/ament_index/resource_index/packages',


### PR DESCRIPTION
<!--
- Please fill the sections below and the PR metadata.
- Make it readable for reviewers and future visitors.
-->

### Description
<!--- Describe your changes in detail -->
Fixed build warnings.
```bash
--- stderr: smach                   
/usr/local/lib/python3.10/dist-packages/setuptools/dist.py:151: UserWarning: newlines not allowed and will break in the future
  warnings.warn("newlines not allowed and will break in the future")
---

/usr/local/lib/python3.10/dist-packages/setuptools/dist.py:717: UserWarning: Usage of dash-separated 'script-dir' will not be supported in future versions. Please use the underscore name 'script_dir' instead

 warnings.warn(
/usr/local/lib/python3.10/dist-packages/setuptools/dist.py:717: UserWarning: Usage of dash-separated 'install-scripts' will not be supported in future versions. Please use the underscore name 'install_scripts' instead


```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### How Has This Been Tested?
<!--- Help reviewers by providing explanations, code snippets, checklists, etc. -->
```
 mkdir -p ~/test_ws/src/
cd ~/test_ws/src/
git clone git@github.com:DeepX-inc/executive_smach.git -b fix/warnings

docker run --name test_system -dt --rm -v ~/test_ws/src:/root/deepx_ws/src "ghcr.io/deepx-inc/base_images:1.4.0-humble-cuda"

docker exec -it test_system bash
pip3 install setuptools==58.2.0
cd /root/deepx_ws/
colcon build
colcon test

exit

docker stop test_system

```
---

- [PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md)