### PR TITLE
Disable parameter services

### DIFF
--- a/smach_ros/smach_ros/introspection.py
+++ b/smach_ros/smach_ros/introspection.py
@@ -266,7 +266,11 @@ class IntrospectionServer(Node):
     def __init__(self, server_name, state, path):
         """Traverse the smach tree starting at root, and construct introspection
         proxies for getting and setting debug state."""
-        Node.__init__(self, server_name)
+        Node.__init__(
+            self,
+            server_name,
+            start_parameter_services=False,
+        )
 
         # A list of introspection proxies
         self._proxies = []


### PR DESCRIPTION
### Description

Disable ROS Node parameter services.

### Motivation and Context

Mitigate network strain because of DDS discovery over WiFi.

The following services are suppressed now:
- `~/describe_parameters`
- `~/get_parameter_types`
- `~/get_parameters`
- `~/list_parameters`
- `~/set_parameters`
- `~/set_parameters_atomically`

The services are not needed.

### How Has This Been Tested?

```bash
# ... (secret) launch command used by the project ...
ros2 service list
```


<br>
---

- [DeepX PR Guidelines](https://github.com/DeepX-inc/.github/blob/main/pull_request_guidelines.md) - for descriptions and metadata.
- [Google Code Review Guidelines](https://google.github.io/eng-practices/) - for [authors](https://google.github.io/eng-practices/review/developer/) and [reviewers](https://google.github.io/eng-practices/review/reviewer/).
- [Semantic Code Reviews](https://www.m31coding.com/blog/semantic-reviews.html) - Simple and direct comments without drama.
